### PR TITLE
Fix build on FreeBSD/powerpc64le.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,7 +494,7 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm*")
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "mips")
   # Just to avoid the “unknown processor” error.
   set(ARCH "generic")
-elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(powerpc64le.*|ppc64le.*|PPC64LE.*)")
   set(ARCH "ppc64le")
 else()
   message(FATAL_ERROR "Unknown processor:" ${CMAKE_SYSTEM_PROCESSOR})

--- a/crypto/cpu-ppc64le.c
+++ b/crypto/cpu-ppc64le.c
@@ -28,7 +28,11 @@
 #endif
 
 void OPENSSL_cpuid_setup(void) {
+#if defined(__linux__)
   OPENSSL_ppc64le_hwcap2 = getauxval(AT_HWCAP2);
+#elif defined(__FreeBSD__)
+  elf_aux_info(AT_HWCAP2, &OPENSSL_ppc64le_hwcap2, sizeof(OPENSSL_ppc64le_hwcap2));
+#endif
 }
 
 int CRYPTO_is_PPC64LE_vcrypto_capable(void) {


### PR DESCRIPTION
1. Check alternative architecture strings on ppc64le.
2. Use elf_aux_info() instead of getauxval() on FreeBSD.