### PR TITLE
Fix build on FreeBSD/powerpc64le

### DIFF
--- a/crypto/cpu-ppc64le.c
+++ b/crypto/cpu-ppc64le.c
@@ -28,7 +28,10 @@
 #endif
 
 void OPENSSL_cpuid_setup(void) {
+#if defined(__linux__)
   OPENSSL_ppc64le_hwcap2 = getauxval(AT_HWCAP2);
+#elif defined(__FreeBSD__)
+  elf_aux_info(AT_HWCAP2, &OPENSSL_ppc64le_hwcap2, sizeof(OPENSSL_ppc64le_hwcap2));
 }
 
 int CRYPTO_is_PPC64LE_vcrypto_capable(void) {


### PR DESCRIPTION
FreeBSD uses elf_aux_info() instead of getauxval().
