### PR TITLE
add loongarch64 support

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -109,6 +109,8 @@ extern "C" {
 #define OPENSSL_64_BIT
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
 #define OPENSSL_32_BIT
+#elif defined(__loongarch64)
+#define OPENSSL_64_BIT
 #elif defined(__pnacl__)
 #define OPENSSL_32_BIT
 #define OPENSSL_PNACL


### PR DESCRIPTION
Add support for building on `linux-loongarch64`.